### PR TITLE
Update Mazda BT-50: Add Wikipedia reference and standard README template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Mazda BT-50
 
+This repository contains signal set configurations for the Mazda BT-50, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mazda BT-50.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mazda_BT-50"
+
 generations:
   - name: "First Generation"
     start_year: 2006


### PR DESCRIPTION
- Added references array with Wikipedia URL to generations.yaml
- Updated README.md with standard template
- Verified generational data matches Wikipedia article:
  - First Generation (2006-2011): UN platform, Ford Ranger based
  - Second Generation (2012-2020): UP/UR platform, facelifts in 2015 and 2018
  - Third Generation (2021-present): TF platform, Isuzu D-Max based
